### PR TITLE
feat(db): add SQLAlchemy DB wiring, models and DB initialization

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 fastapi
 uvicorn
+sqlalchemy
+alembic

--- a/src/db.py
+++ b/src/db.py
@@ -1,0 +1,19 @@
+import os
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker, declarative_base
+
+DATABASE_URL = os.environ.get("DATABASE_URL", "sqlite:///./dev.db")
+
+# For SQLite we need check_same_thread=False
+connect_args = {"check_same_thread": False} if DATABASE_URL.startswith("sqlite") else {}
+engine = create_engine(DATABASE_URL, connect_args=connect_args)
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+Base = declarative_base()
+
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()

--- a/src/models.py
+++ b/src/models.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, Integer, String, Text, ForeignKey
+from sqlalchemy import Column, Integer, String, Text, ForeignKey, UniqueConstraint
 from sqlalchemy.orm import relationship
 from .db import Base
 
@@ -17,5 +17,9 @@ class Participant(Base):
     __tablename__ = "participants"
     id = Column(Integer, primary_key=True, index=True)
     email = Column(String(200), index=True, nullable=False)
-    activity_id = Column(Integer, ForeignKey("activities.id"))
+    activity_id = Column(Integer, ForeignKey("activities.id", ondelete="CASCADE"))
     activity = relationship("Activity", back_populates="participants")
+
+    __table_args__ = (
+        UniqueConstraint("email", "activity_id", name="uq_participant_email_activity"),
+    )

--- a/src/models.py
+++ b/src/models.py
@@ -1,0 +1,21 @@
+from sqlalchemy import Column, Integer, String, Text, ForeignKey
+from sqlalchemy.orm import relationship
+from .db import Base
+
+
+class Activity(Base):
+    __tablename__ = "activities"
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String(200), unique=True, index=True, nullable=False)
+    description = Column(Text)
+    schedule = Column(String(200))
+    max_participants = Column(Integer, default=0)
+    participants = relationship("Participant", back_populates="activity", cascade="all, delete-orphan")
+
+
+class Participant(Base):
+    __tablename__ = "participants"
+    id = Column(Integer, primary_key=True, index=True)
+    email = Column(String(200), index=True, nullable=False)
+    activity_id = Column(Integer, ForeignKey("activities.id"))
+    activity = relationship("Activity", back_populates="participants")


### PR DESCRIPTION
This PR adds a simple SQLAlchemy-based persistence layer and initial DB seed.

What changed:
- Added `src/db.py` (SQLAlchemy engine, session, Base)
- Added `src/models.py` (Activity, Participant models)
- Updated `src/app.py` to use the DB instead of the in-memory dict and to seed initial activities on startup
- Updated `requirements.txt` to include `sqlalchemy` and `alembic` (for future migrations)

Notes:
- This change uses `Base.metadata.create_all()` to create tables at startup. For production migrations, run Alembic (`alembic init`, `alembic revision --autogenerate`, `alembic upgrade head`) or I can add an Alembic environment in a follow-up PR.
- The DB URL is configurable via the `DATABASE_URL` environment variable. By default it uses `sqlite:///./dev.db`.

Please review the changes and let me know if you prefer Alembic migrations added right away or if you'd like a different DB (Postgres) configured as part of this PR.